### PR TITLE
add trace macro with tests; some ASCIIString->String

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.5-
 DataStructures
 RecipesBase

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,9 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
-
-branches:
-  only:
-    - master
-    - /release-.*/
 
 notifications:
   - provider: Email
@@ -17,10 +12,13 @@ notifications:
     on_build_status_changed: false
 
 install:
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
 # Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
-        "C:\projects\julia-binary.exe")
+  - ps: (new-object net.webclient).DownloadFile($("http://s3.amazonaws.com/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia
 

--- a/src/ValueHistories.jl
+++ b/src/ValueHistories.jl
@@ -10,12 +10,14 @@ export
         VectorUnivalueHistory,
         QueueUnivalueHistory,
       MultivalueHistory,
-        DynMultivalueHistory
+        DynMultivalueHistory,
+    @trace
 
 include("abstract_history.jl")
 include("queue_uv_history.jl")
 include("vector_uv_history.jl")
 include("dyn_mv_history.jl")
 include("recipes.jl")
+
 
 end # module

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.4
-BaseTestNext

--- a/test/bm_history.jl
+++ b/test/bm_history.jl
@@ -73,4 +73,4 @@ msg("DynMultivalueHistory: Converting result into arrays")
 @time x,y = get(_history, :mystr)
 
 @assert length(y) == n
-@assert typeof(y) <: Vector{ASCIIString}
+@assert typeof(y) <: Vector{String}

--- a/test/tst_dyn_mv_history.jl
+++ b/test/tst_dyn_mv_history.jl
@@ -77,8 +77,7 @@ end
     x = linspace(0,1,n)
     for i = 1:n
         xi = x[i]
-        @test @trace(_history, i, xi) == xi
-        @test @trace(_history, i, round(Int,xi)) == round(Int,xi)
+        @test @trace(_history, i, xi, round(Int,xi)) == round(Int,xi)
     end
 
     @test haskey(_history, :xi)

--- a/test/tst_dyn_mv_history.jl
+++ b/test/tst_dyn_mv_history.jl
@@ -63,10 +63,35 @@ end
 
     a1, a2 = get(_history, :mystring)
     @test typeof(a1) <: Vector{UInt8}
-    @test typeof(a2) <: Vector{ASCIIString}
+    @test typeof(a2) <: Vector{String}
 
     a1, a2 = get(_history, :myfloat)
     @test typeof(a1) <: Vector{UInt8}
     @test typeof(a2) <: Vector{Float32}
 end
 
+
+@testset "DynMultivalueHistory: @trace" begin
+    _history = DynMultivalueHistory()
+    n = 2
+    x = linspace(0,1,n)
+    for i = 1:n
+        xi = x[i]
+        @test @trace(_history, i, xi) == xi
+        @test @trace(_history, i, round(Int,xi)) == round(Int,xi)
+    end
+
+    @test haskey(_history, :xi)
+    a1, a2 = get(_history, :xi)
+    @test length(a1) == n
+    @test length(a2) == n
+    @test typeof(a1) <: Vector{Int}
+    @test typeof(a2) <: Vector{Float64}
+
+    @test haskey(_history, Symbol("round(Int,xi)"))
+    a1, a2 = get(_history, Symbol("round(Int,xi)"))
+    @test length(a1) == n
+    @test length(a2) == n
+    @test typeof(a1) <: Vector{Int}
+    @test typeof(a2) <: Vector{Int}
+end

--- a/test/tst_stat_uv_history.jl
+++ b/test/tst_stat_uv_history.jl
@@ -49,7 +49,7 @@ for T in [VectorUnivalueHistory, QueueUnivalueHistory]
     end
 
     @testset "$(T.name.name): Storing arbitrary types" begin
-        _history = T(ASCIIString, UInt8)
+        _history = T(String, UInt8)
 
         for i = 1:100
             @test push!(_history, i % UInt8, string("i=", i + 1)) == string("i=", i+1)
@@ -59,6 +59,6 @@ for T in [VectorUnivalueHistory, QueueUnivalueHistory]
 
         a1, a2 = get(_history)
         @test typeof(a1) <: Vector{UInt8}
-        @test typeof(a2) <: Vector{ASCIIString}
+        @test typeof(a2) <: Vector{String}
     end
 end


### PR DESCRIPTION
This adds a convenience macro `@trace` to compactly add some variables to a DynMultivalueHistory.

``` julia
using ValueHistories, OnlineStats
v = Variance(BoundedEqualWeight(30))
tr = DynMultivalueHistory()
for i=1:100
    r = rand()
    fit!(v,r)
    μ,σ = mean(v),std(v)

    # add entries for :r, :μ, and :σ using their current values
    @trace tr i r μ σ
end

# plot it
using Plots; gr()
plot(tr[:r])
plot!(tr[:μ], ribbon=tr[:σ].values, f=0.4)
```

![tmp](https://cloud.githubusercontent.com/assets/933338/17818485/c6453866-6611-11e6-9dbe-73ffa638cf9b.png)
