### PR TITLE
Add keys and values function for MVHistory.

### DIFF
--- a/src/mvhistory.jl
+++ b/src/mvhistory.jl
@@ -14,6 +14,8 @@ Base.length(history::MVHistory, key::Symbol) = length(history.storage[key])
 Base.enumerate(history::MVHistory, key::Symbol) = enumerate(history.storage[key])
 Base.first(history::MVHistory, key::Symbol) = first(history.storage[key])
 Base.last(history::MVHistory, key::Symbol) = last(history.storage[key])
+Base.keys(history::MVHistory) = keys(history.storage)
+Base.values(history::MVHistory, key::Symbol) = get(history, key)[2]
 
 function Base.push!(
         history::MVHistory{H},

--- a/test/tst_mvhistory.jl
+++ b/test/tst_mvhistory.jl
@@ -21,6 +21,11 @@
 
     @test_throws ArgumentError push!(_history, :myf, 200, "test")
 
+    for k in keys(_history)
+        @test k in [:myf, :myint, :myint2]
+    end
+    @test values(_history, :myf) == numbers + 1
+    @test_throws KeyError values(_history, :abc)
     @test first(_history, :myf) == (-10, -9)
     @test last(_history, :myf) == (100, 101)
     @test first(_history, :myint) == (0, -1)


### PR DESCRIPTION
This PR adds the convenience helper functions `keys` and `values` for a MVHistory.