### PR TITLE
Use Array{} instead of zeros() in get() functions

### DIFF
--- a/src/mvhistory.jl
+++ b/src/mvhistory.jl
@@ -55,7 +55,7 @@ Base.haskey(history::MVHistory, key::Symbol) = haskey(history.storage, key)
 function Base.get(history::MVHistory, key::Symbol)
     l = length(history, key)
     k, v = first(history.storage[key])
-    karray = zeros(typeof(k), l)
+    karray = Array{typeof(k)}(undef, l)
     varray = Array{typeof(v)}(undef, l)
     i = 1
     for (k, v) in enumerate(history, key)

--- a/src/qhistory.jl
+++ b/src/qhistory.jl
@@ -38,7 +38,7 @@ end
 function Base.get(history::QHistory{I,V}) where {I,V}
     l = length(history)
     k, v = front(history.storage)
-    karray = zeros(I, l)
+    karray = Array{I}(undef, l)
     varray = Array{V}(undef, l)
     i = 1
     for (k, v) in enumerate(history)


### PR DESCRIPTION
Allow keys of type `T`, which have no `zero(::T)` defined (`DateTime`, for example).