### PR TITLE
Add drop! method to (MV)History

### DIFF
--- a/src/ValueHistories.jl
+++ b/src/ValueHistories.jl
@@ -12,7 +12,8 @@ export
       MultivalueHistory,
         MVHistory,
         increment!,
-    @trace
+    @trace,
+    drop!
 
 include("abstract.jl")
 include("history.jl")

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -10,3 +10,18 @@ Base.push!(history::UnivalueHistory, iteration, value) =
 # get(history::ValueHistory) = error()
 # first(history::ValueHistory) = error()
 # last(history::ValueHistory) = error()
+
+"""
+    drop!(hist, it)
+
+Deletes all values stored for iterations greater than `it`. If
+`it>first(last(hist))` then it does nothing.
+"""
+function drop!(history::UnivalueHistory, it)
+    iter, vals = get(history)
+    n = findlast(x->x<=it, iter)
+    isnothing(n) && return last(iter)
+
+    resize!(history, n)
+    return history.lastiter
+end

--- a/src/history.jl
+++ b/src/history.jl
@@ -45,6 +45,15 @@ function Base.show(io::IO, history::History{I,V}) where {I,V}
     print(io,   "  * length: $(length(history))")
 end
 
+function Base.resize!(history::History, n)
+    iter, vals = get(history)
+    resize!(iter, n)
+    resize!(vals, n)
+    history.lastiter = last(iter)
+
+    history
+end
+
 """
     increment!(trace, iter, val)
 

--- a/src/mvhistory.jl
+++ b/src/mvhistory.jl
@@ -116,3 +116,17 @@ function increment!(trace::MVHistory{<:History}, key::Symbol, iter::Number, val)
     end
     push!(trace, key, iter, val)
 end
+
+"""
+    drop!(hist, it)
+
+Deletes all values stored for iterations greater than `it` for all
+keys stored in `hist`.
+"""
+function drop!(history::MVHistory, it)
+    lastiters = Int[]
+    for hist=values(history.storage)
+        push!(lastiters, drop!(hist, it))
+    end
+    maximum(lastiters)
+end

--- a/src/qhistory.jl
+++ b/src/qhistory.jl
@@ -49,6 +49,18 @@ function Base.get(history::QHistory{I,V}) where {I,V}
     karray, varray
 end
 
+function Base.resize!(history::QHistory, n)
+    @assert n <= length(history)
+
+    storage = history.storage
+    while n<length(storage)
+        it, val = pop!(storage)
+    end
+    history.lastiter = first(last(history))
+
+    history
+end
+
 Base.print(io::IO, history::QHistory{I,V}) where {I,V} = print(io, "$(length(history)) elements {$I,$V}")
 
 function Base.show(io::IO, history::QHistory{I,V}) where {I,V}


### PR DESCRIPTION
This PR aims to provide a method, `drop!(hist, it)` which drops all values stored in an `History` object for iterations above `it`. 

If you like the idea, I'll add the relevant tests and update the docs. 