### PR TITLE
Convert to Dataframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,16 @@ version = "0.5.2"
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-DataStructures = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16"
-RecipesBase = "0.2.3, 0.3, 0.4, 0.5"
+DataStructures = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17"
+RecipesBase = "0, 1"
+Requires = "1"
 julia = "1"
 
 [extras]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/src/ValueHistories.jl
+++ b/src/ValueHistories.jl
@@ -2,6 +2,7 @@ module ValueHistories
 
 using DataStructures
 using RecipesBase
+using Requires
 
 export
 
@@ -19,5 +20,9 @@ include("history.jl")
 include("qhistory.jl")
 include("mvhistory.jl")
 include("recipes.jl")
+
+function __init__()
+    @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" include("dataframe.jl")
+end
 
 end # module

--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -1,0 +1,12 @@
+function Base.convert(::Type{DataFrame}, h::MVHistory)
+    names = collect(keys(h))
+    dfs = map(names) do key
+        iters, vals = get(h, key)
+        DataFrame([iters, vals], [:iter, key])
+    end
+    return join(dfs..., on = :iter, kind = :outer)
+end
+
+function Base.convert(::Type{DataFrame}, h::History)
+    DataFrame(get(h), [:iter, :val])
+end

--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -1,3 +1,5 @@
+using .DataFrames
+
 function Base.convert(::Type{DataFrame}, h::MVHistory)
     names = collect(keys(h))
     dfs = map(names) do key
@@ -8,5 +10,5 @@ function Base.convert(::Type{DataFrame}, h::MVHistory)
 end
 
 function Base.convert(::Type{DataFrame}, h::History)
-    DataFrame(get(h), [:iter, :val])
+    DataFrame(collect(get(h)), [:iter, :val])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,11 @@
 using ValueHistories
 using Test
+using DataFrames
 
 tests = [
     "tst_history.jl"
     "tst_mvhistory.jl"
+    "tst_dataframe.jl"
 ]
 
 perf = [

--- a/test/tst_dataframe.jl
+++ b/test/tst_dataframe.jl
@@ -1,0 +1,20 @@
+@testset "DataFrame" begin
+    h = History(Float64)
+    mvh = MVHistory()
+    for i in 1:10
+        push!(h, i, rand())
+        push!(mvh, :val1, i, "$i")
+        push!(mvh, :val2, i, rand(3))
+    end
+
+    dfh = convert(DataFrame, h)
+    @test names(dfh) == [:iter, :val]
+    @test size(dfh) == (10, 2)
+    @test eltype(dfh.val) == Float64
+
+    push!(mvh, :val1, 13, "notmissing")
+    dfmvh = convert(DataFrame, mvh)
+    @test names(dfmvh) == vcat(:iter, collect(keys(mvh)))
+    @test size(dfmvh) == (11, 3)
+    @test eltype(dfmvh.val1) == Union{Missing, String}
+end


### PR DESCRIPTION
Hi!
I added a `convert` function to `DataFrame`. I only added the requirement for `DataFrames` via `Requires` so it does not become a heavy dependency.
For `MVHistory` the method is pretty simple : make a `DataFrame` for each `History` and join them via the `outer` method : http://juliadata.github.io/DataFrames.jl/v0.20/man/joins/

The goal is to make the package more compatible with `DrWatson.jl` which relies a lot on `DataFrames`