### PR TITLE
Fixed application of filter function for MVHistory in plot receipes

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -3,7 +3,7 @@ _is_plotable_history(::QHistory{I,V}) where {I,V<:Real} = true
 _is_plotable_history(::History{I,V}) where {I,V<:Real} = true
 
 _filter_plotable_histories(h::MVHistory) =
-    filter((k,v) -> _is_plotable_history(v), h.storage)
+    filter(p -> _is_plotable_history(p.second), h.storage)
 
 @recipe function plot(h::Union{History,QHistory})
     markershape --> :ellipse


### PR DESCRIPTION
Since version 1.0 julia passes a Pair to the filter function when applied to a Dict.